### PR TITLE
fix: focus lost after image upload

### DIFF
--- a/src/quill.imageUploader.js
+++ b/src/quill.imageUploader.js
@@ -129,6 +129,8 @@ class ImageUploader {
                     this.options.upload(file).then(
                         (imageUrl) => {
                             this.insertToEditor(imageUrl);
+                            // Set focus to the editor after successful upload
+                            this.quill.focus();
                         },
                         (error) => {
                             isUploadReject = true;
@@ -171,7 +173,8 @@ class ImageUploader {
         // Insert the server saved image
         this.quill.insertEmbed(range.index, "image", `${url}`, "user");
 
-        range.index++;
+        // Update the range to place the cursor after the inserted image
+        range.index += 1;
         this.quill.setSelection(range, "user");
     }
 


### PR DESCRIPTION
## Fix
This PR fixes the issue where editor focus is going to first line of the editor after image upload is handled.
